### PR TITLE
Logging: reworked logging to give module name for --debug

### DIFF
--- a/m3/ice.py
+++ b/m3/ice.py
@@ -21,7 +21,7 @@ import time
 import os
 
 from . import m3_logging
-logger = m3_logging.getGlobalLogger()
+logger = m3_logging.getLogger(__name__)
 
 try:
     import threading

--- a/m3/m3_common.py
+++ b/m3/m3_common.py
@@ -28,7 +28,7 @@ import imp
 from . import __version__ 
 
 from . import m3_logging
-logger = m3_logging.getGlobalLogger()
+logger = m3_logging.getLogger(__name__)
 
 from .ice import ICE
 from .ice_simulator import _FAKE_SERIAL_CONNECTTO_ENDPOINT

--- a/m3/m3_ice.py
+++ b/m3/m3_ice.py
@@ -17,7 +17,7 @@ from .m3_common import goc_programmer
 from .m3_mbus import mbus_controller 
 
 from . import m3_logging
-logger = m3_logging.getGlobalLogger()
+logger = m3_logging.getLogger(__name__)
 
 class m3_ice(m3_common):
     TITLE = "M3 ICE Interface"

--- a/m3/m3_logging.py
+++ b/m3/m3_logging.py
@@ -85,27 +85,53 @@ def trace(fn):
 
 no_trace_filter = NoTraceFilter()
 
-def get_logger(name):
-	l = logging.getLogger(name)
-	l.level = logging.DEBUG
-	try:
-		l.addHandler(get_logger.handler)
-	except AttributeError:
-		h = logging.StreamHandler()
-		h.level = logging.DEBUG
-		h.addFilter(NoTraceFilter())
-		get_logger.handler = h
-		l.addHandler(get_logger.handler)
-	try:
-		get_logger.handler.setFormatter(get_logger.formatter)
-	except AttributeError:
-		f = DefaultFormatter()
-		get_logger.formatter = f
-		get_logger.handler.setFormatter(get_logger.formatter)
+class LoggerManager (object):
+    
+    def __init__(this):
 
-	l.trace = lambda msg, l=l: l.log(TRACE_LEVEL, msg)
+        this.level = logging.DEBUG 
 
-	return l
+        this.f = DefaultFormatter()
+
+        this.h = logging.StreamHandler()
+        this.h.setFormatter(this.f)
+        this.h.level = logging.INFO
+        this.h.addFilter(NoTraceFilter())
+
+        this.debugFormat = "%(levelname)s\t%(name)s\t%(message)s"
+
+    def getLogger(this, name):
+        l = logging.getLogger(name)
+
+        l.level = this.level
+        l.addHandler(this.h)
+        l.trace = lambda msg, l=l: l.log(TRACE_LEVEL, msg)
+
+        return l
+
+    def updateLevel(this, log_level):
+       
+        if isinstance(log_level, int): 
+            this.h.level = log_level
+            if log_level == logging.DEBUG:
+                this.updateFormat(this.debugFormat)
+            else: this.updateFormat()
+
+        else: # if called with strings, recurse with the level
+            if log_level.lower() in ['debug']:
+                this.updateLevel(logging.DEBUG)
+            elif log_level.lower() in ['info']:
+                this.updateLevel(logging.INFO)
+            elif log_level.lower() in ['warn']:
+                this.updateLevel(logging.WARN)
+            else: raise Exception("Bad Level")
+
+    def updateFormat(this, fmt=None):
+        if fmt!= None:
+            this.f = DefaultFormatter(fmt=fmt)
+        else:
+            this.f = DefaultFormatter()
+        this.h.setFormatter(this.f)
 
 #def log_level_from_environment():
 #	try:
@@ -114,16 +140,23 @@ def get_logger(name):
 #	except KeyError:
 #		return logging.INFO
 
-logger = get_logger(__name__)
+# logger manager
+logMan = LoggerManager() 
 
-def LoggerSetLevel(lvl):
-    if lvl.lower() in ['debug']:
-       logger.setLevel ( logging.DEBUG)
-    elif lvl.lower() in ['info']:
-       logger.setLevel ( logging.INFO)
-    else: raise Exception('unsupported level')
-
-logger = get_logger(__name__)
+#and a global logger
+glob_logger = logMan.getLogger(__name__)
 
 def getGlobalLogger():
-    return logger
+    return glob_logger
+
+def LoggerSetLevel(lvl):
+    logMan.updateLevel(lvl)
+
+def get_logger(name):
+    return logMan.getLogger(name)
+
+#maintain API compatability with the logger module
+def getLogger(name):
+    return logMan.getLogger(name)
+
+

--- a/m3/m3_mbus.py
+++ b/m3/m3_mbus.py
@@ -42,7 +42,7 @@ import imp
 from . import __version__ 
 
 from . import m3_logging
-logger = m3_logging.getGlobalLogger()
+logger = m3_logging.getLogger(__name__)
 
 
 


### PR DESCRIPTION
Uses the standard "LEVEL MESSAGE" format for non-debug output, but if the --debug flag is passed, it switches to "LEVEL MODULE MESSAGE" formatting